### PR TITLE
⚠ Add +required tag and make optional default

### DIFF
--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -619,7 +619,7 @@ func (b *APIs) getMembers(t *types.Type, found sets.String) (map[string]v1beta1.
 			m, r := b.typeToJSONSchemaProps(member.Type, found, member.CommentLines, false)
 			members[name] = m
 			result[name] = r
-			if !strings.HasSuffix(strat, "omitempty") {
+			if hasRequired(t) {
 				required = append(required, name)
 			}
 		}

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -231,6 +231,18 @@ func hasSingular(t *types.Type) bool {
 	return false
 }
 
+// hasRequired returns true if t is annotated with
+// +required
+func hasRequired(t *types.Type) bool {
+	for _, c := range append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...) {
+		c = strings.TrimSpace(c)
+		if c == "+required" {
+			return true
+		}
+	}
+	return false
+}
+
 // IsUnversioned returns true if t is in given group, and not in versioned path.
 func IsUnversioned(t *types.Type, group string) bool {
 	return IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) && GetGroup(t) == group


### PR DESCRIPTION
This flips the default behavior of the CRD generation tool to assume all fields are optional unless otherwise specified with a `// +required` comment
