### PR TITLE
✨ Add plural name tag

### DIFF
--- a/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
+++ b/pkg/crd/generator/testData/config/crds/fun_v1alpha1_toy.yaml
@@ -28,7 +28,7 @@ spec:
   group: fun.myk8s.io
   names:
     kind: Toy
-    plural: services
+    plural: toys
     shortNames:
     - to
     - ty

--- a/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
+++ b/pkg/crd/generator/testData/pkg/apis/fun/v1alpha1/toy_types.go
@@ -106,6 +106,7 @@ type ToyStatus struct {
 // +kubebuilder:printcolumn:name="service",type="string",JSONPath=".status.conditions.ready",description="descr3",format="byte",priority=2
 // +kubebuilder:resource:path=services,shortName=to;ty
 // +kubebuilder:singular=toy
+// +kubebuilder:plural=toys
 type Toy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/internal/codegen/parse/crd.go
+++ b/pkg/internal/codegen/parse/crd.go
@@ -91,6 +91,11 @@ func (b *APIs) parseCRDs() {
 						resource.CRD.Spec.Names.Singular = singularName
 					}
 
+					if hasPlural(resource.Type) {
+						pluralName := getPluralName(resource.Type)
+						resource.CRD.Spec.Names.Plural = pluralName
+					}
+
 					if hasStatusSubresource(resource.Type) {
 						if resource.CRD.Spec.Subresources == nil {
 							resource.CRD.Spec.Subresources = &v1beta1.CustomResourceSubresources{}

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -231,6 +231,20 @@ func hasSingular(t *types.Type) bool {
 	return false
 }
 
+// hasPlural returns true if t is an APIResource annotated with
+// +kubebuilder:plural
+func hasPlural(t *types.Type) bool {
+	if !IsAPIResource(t) {
+		return false
+	}
+	for _, c := range append(append([]string{}, t.SecondClosestCommentLines...), t.CommentLines...) {
+		if strings.Contains(c, "+kubebuilder:plural"){
+			return true
+		}
+	}
+	return false
+}
+
 // hasRequired returns true if t is annotated with
 // +required
 func hasRequired(t *types.Type) bool {
@@ -345,6 +359,16 @@ func getSingularName(c *types.Type) string {
 		panic(errors.Errorf("Must specify a value to use with +kubebuilder:singular comment for type %v", c.Name))
 	}
 	return singular
+}
+
+// getPluralName returns the value of the +kubebuilder:plural tag
+func getPluralName(c *types.Type) string {
+	comments := Comments(append(append([]string{}, c.SecondClosestCommentLines...), c.CommentLines...))
+	plural := comments.getTag("kubebuilder:plural", "=")
+	if len(plural) == 0 {
+		panic(errors.Errorf("Must specify a value to use with +kubebuilder:plural comment for type %v", c.Name))
+	}
+	return plural
 }
 
 // getDocAnnotation parse annotations of "+kubebuilder:doc:" with tags of "warning" or "doc" for control generating doc config.


### PR DESCRIPTION
As requested in https://github.com/openshift/origin/pull/22126#issuecomment-466397643, adds a `// +kubebuilder:plural=foo` tag 
