### PR TITLE
FeatureSet Aware Enum should account for multiple feature sets

### DIFF
--- a/pkg/crd/markers/patch_validation.go
+++ b/pkg/crd/markers/patch_validation.go
@@ -38,12 +38,12 @@ func init() {
 }
 
 type FeatureSetEnum struct {
-	FeatureSetName string   `marker:"featureSet"`
-	EnumValues     []string `marker:"enum"`
+	FeatureSetNames []string `marker:"featureSet"`
+	EnumValues      []string `marker:"enum"`
 }
 
 func (m FeatureSetEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !RequiredFeatureSets.Has(m.FeatureSetName) {
+	if !RequiredFeatureSets.HasAny(m.FeatureSetNames...) {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Currently, you can set a single featureset for a `FeatureSetAwareEnum`, eg,
```
// +openshift:validation:FeatureSetAwareEnum:featureSet=TechPreviewNoUpgrade,enum="";StableValue;TechPreviewOnlyValue
```
But, it would be useful to be able to handle additional featuresets in the same line, eg, 
```
// +openshift:validation:FeatureSetAwareEnum:featureSet=CustomNoUpgrade;TechPreviewNoUpgrade,enum="";StableValue;TechPreviewOnlyValue
```

To achieve this, I've changed the code to handle multiple feature sets

Tested locally while trying to set up `CustomNoUpgrade` CRDs