### PR TITLE
Add a concept of requiredFeatureGate to each gateable marker

### DIFF
--- a/pkg/crd/markers/patch_validation.go
+++ b/pkg/crd/markers/patch_validation.go
@@ -122,12 +122,23 @@ func (m FeatureSetXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) err
 func (m FeatureSetXValidation) ApplyFirst() {}
 
 type FeatureGateEnum struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	EnumValues       []string `marker:"enum"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate"`
+	EnumValues               []string `marker:"enum"`
 }
 
 func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 
@@ -150,12 +161,23 @@ func (m FeatureGateEnum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 }
 
 type FeatureGateMaxItems struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	MaxItems         int      `marker:"maxItems"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate"`
+	MaxItems                 int      `marker:"maxItems"`
 }
 
 func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 
@@ -168,13 +190,24 @@ func (m FeatureGateMaxItems) ApplyToSchema(schema *apiext.JSONSchemaProps) error
 }
 
 type FeatureGateXValidation struct {
+	// FeatureGateNames represents the optional feature gates that can enable this field.
+	// If any of the feature gates are enabled, the field will be enabled.
 	FeatureGateNames []string `marker:"featureGate"`
-	Rule             string
-	Message          string `marker:",optional"`
+	// RequiredFeatureGateNames represents the required feature gates that must be enabled to enable this field.
+	// If any of the required feature gates are not enabled, the field will not be enabled.
+	RequiredFeatureGateNames []string `marker:"requiredFeatureGate"`
+	Rule                     string
+	Message                  string `marker:",optional"`
 }
 
 func (m FeatureGateXValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if !FeatureGatesForCurrentFile.HasAny(m.FeatureGateNames...) {
+	if !FeatureGatesForCurrentFile.HasAny(append(m.FeatureGateNames, m.RequiredFeatureGateNames...)...) {
+		// No required or optional feature gates are enabled, so we don't need to apply this marker
+		return nil
+	}
+
+	if !FeatureGatesForCurrentFile.HasAll(m.RequiredFeatureGateNames...) {
+		// Not all required feature gates are enabled, so we don't need to apply this marker
 		return nil
 	}
 


### PR DESCRIPTION
We recently had a case where we needed a gate aware validation to apply only when 2 gates were active within a set.

This updates the existing gateable validations (enum, XValidation, MaxLength) so that they have the original concept or optional gates (OR) and required gates (AND).

This will allow us to add validations in the future where they may cross multiple feature gate boundaries
