### PR TITLE
Fix FeatureSetAwareXValidation registration

### DIFF
--- a/pkg/crd/markers/patch_validation.go
+++ b/pkg/crd/markers/patch_validation.go
@@ -62,7 +62,7 @@ func init() {
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureGate that is required to generate this field.")),
 	)
 	ValidationMarkers = append(ValidationMarkers,
-		must(markers.MakeDefinition(OpenShiftFeatureGateAwareXValidationMarkerName, markers.DescribesType, FeatureGateXValidation{})).
+		must(markers.MakeDefinition(OpenShiftFeatureGateAwareXValidationMarkerName, markers.DescribesField, FeatureGateXValidation{})).
 			WithHelp(markers.SimpleHelp("OpenShift", "specifies the FeatureGate that is required to generate this XValidation rule.")),
 	)
 }


### PR DESCRIPTION
This is a no-op on the current o/api repo, as all feature set aware XValidations so far have applied only to struct types. However, I would now like to add a new validation to a field, and unless we move this to DescribesField, the marker is not picked up.

Background context is that we are expanding a list from maxItems 1 to maxItems 32, and would like to apply a validation to make sure all items in the list are unique.

Tested locally, a no-op for the current repo but fixes the patch we are trying to add.
