### PR TITLE
[release-4.18] markers: add support for optionalOldSelf in XValidation marker

### DIFF
--- a/pkg/crd/markers/validation.go
+++ b/pkg/crd/markers/validation.go
@@ -332,6 +332,7 @@ type XValidation struct {
 	MessageExpression string `marker:"messageExpression,optional"`
 	Reason            string `marker:"reason,optional"`
 	FieldPath         string `marker:"fieldPath,optional"`
+	OptionalOldSelf   *bool  `marker:"optionalOldSelf,optional"`
 }
 
 func (m Maximum) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
@@ -603,6 +604,7 @@ func (m XValidation) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 		MessageExpression: m.MessageExpression,
 		Reason:            reason,
 		FieldPath:         m.FieldPath,
+		OptionalOldSelf:   m.OptionalOldSelf,
 	})
 	return nil
 }

--- a/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/pkg/crd/markers/zz_generated.markerhelp.go
@@ -547,6 +547,10 @@ func (XValidation) Help() *markers.DefinitionHelp {
 				Summary: "",
 				Details: "",
 			},
+			"OptionalOldSelf": {
+				Summary: "",
+				Details: "",
+			},
 		},
 	}
 }

--- a/pkg/crd/testdata/cronjob_types.go
+++ b/pkg/crd/testdata/cronjob_types.go
@@ -338,6 +338,10 @@ type CronJobSpec struct {
 	// +kubebuilder:validation:items:XIntOrString
 	// +kubebuilder:validation:items:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
 	IntOrStringArrayWithAPattern []*intstr.IntOrString `json:"intOrStringArrayWithAPattern,omitempty"`
+
+	// Test that we can add a field that can only be set to a non-default value on updates using XValidation OptionalOldSelf.
+	// +kubebuilder:validation:XValidation:rule="oldSelf.hasValue() || self == 0",message="must be set to 0 on creation. can be set to any value on an update.",optionalOldSelf=true
+	OnlyAllowSettingOnUpdate int32 `json:"onlyAllowSettingOnUpdate,omitempty"`
 }
 
 type ContainsNestedMap struct {

--- a/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
+++ b/pkg/crd/testdata/testdata.kubebuilder.io_cronjobs.yaml
@@ -174,6 +174,14 @@ spec:
                 description: This tests that primitive defaulting can be performed.
                 example: forty-two
                 type: string
+              doubleDefaultedString:
+                default: kubebuilder-default
+                description: This tests that kubebuilder defaulting takes precedence.
+                type: string
+              embeddedResource:
+                type: object
+                x-kubernetes-embedded-resource: true
+                x-kubernetes-preserve-unknown-fields: true
               explicitlyOptionalKubebuilder:
                 description: This tests explicitly optional kubebuilder fields
                 type: string
@@ -186,78 +194,6 @@ spec:
               explicitlyRequiredKubernetes:
                 description: This tests explicitly required kubernetes fields
                 type: string
-              doubleDefaultedString:
-                default: kubebuilder-default
-                description: This tests that kubebuilder defaulting takes precedence.
-                type: string
-              kubernetesDefaultedEmptyMap:
-                additionalProperties:
-                  type: string
-                default: {}
-                description: This tests that an empty object defaulting can be performed
-                  on a map.
-                type: object
-              kubernetesDefaultedEmptyObject:
-                default: {}
-                description: This tests that an empty object defaulting can be performed
-                  on an object.
-                properties:
-                  bar:
-                    type: string
-                  foo:
-                    default: forty-two
-                    type: string
-                type: object
-              kubernetesDefaultedEmptySlice:
-                default: []
-                description: This tests that empty slice defaulting can be performed.
-                items:
-                  type: string
-                type: array
-              kubernetesDefaultedObject:
-                default:
-                - nested:
-                    bar: true
-                    foo: baz
-                - nested:
-                    bar: false
-                    foo: qux
-                description: This tests that slice and object defaulting can be performed.
-                items:
-                  properties:
-                    nested:
-                      properties:
-                        bar:
-                          type: boolean
-                        foo:
-                          type: string
-                      required:
-                      - bar
-                      - foo
-                      type: object
-                  required:
-                  - nested
-                  type: object
-                type: array
-              kubernetesDefaultedSlice:
-                default:
-                - a
-                - b
-                description: This tests that slice defaulting can be performed.
-                items:
-                  type: string
-                type: array
-              kubernetesDefaultedString:
-                default: forty-two
-                description: This tests that primitive defaulting can be performed.
-                type: string
-              kubernetesDefaultedRef:
-                description: This tests that use of +default=ref(...) doesn't break generation
-                type: string
-              embeddedResource:
-                type: object
-                x-kubernetes-embedded-resource: true
-                x-kubernetes-preserve-unknown-fields: true
               failedJobsHistoryLimit:
                 description: |-
                   The number of failed finished jobs to retain.
@@ -6668,6 +6604,71 @@ spec:
                 - bar
                 - foo
                 type: object
+              kubernetesDefaultedEmptyMap:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: This tests that an empty object defaulting can be performed
+                  on a map.
+                type: object
+              kubernetesDefaultedEmptyObject:
+                default: {}
+                description: This tests that an empty object defaulting can be performed
+                  on an object.
+                properties:
+                  bar:
+                    type: string
+                  foo:
+                    default: forty-two
+                    type: string
+                type: object
+              kubernetesDefaultedEmptySlice:
+                default: []
+                description: This tests that empty slice defaulting can be performed.
+                items:
+                  type: string
+                type: array
+              kubernetesDefaultedObject:
+                default:
+                - nested:
+                    bar: true
+                    foo: baz
+                - nested:
+                    bar: false
+                    foo: qux
+                description: This tests that slice and object defaulting can be performed.
+                items:
+                  properties:
+                    nested:
+                      properties:
+                        bar:
+                          type: boolean
+                        foo:
+                          type: string
+                      required:
+                      - bar
+                      - foo
+                      type: object
+                  required:
+                  - nested
+                  type: object
+                type: array
+              kubernetesDefaultedRef:
+                description: This tests that use of +default=ref(...) doesn't break
+                  generation
+                type: string
+              kubernetesDefaultedSlice:
+                default:
+                - a
+                - b
+                description: This tests that slice defaulting can be performed.
+                items:
+                  type: string
+                type: array
+              kubernetesDefaultedString:
+                default: forty-two
+                description: This tests that primitive defaulting can be performed.
+                type: string
               longerStringArray:
                 description: This tests string alias slice item validation.
                 items:
@@ -6790,6 +6791,16 @@ spec:
                   This flag is like suspend, but for when you really mean it.
                   It helps test the +kubebuilder:validation:Type marker.
                 type: string
+              onlyAllowSettingOnUpdate:
+                description: Test that we can add a field that can only be set to
+                  a non-default value on updates using XValidation OptionalOldSelf.
+                format: int32
+                type: integer
+                x-kubernetes-validations:
+                - message: must be set to 0 on creation. can be set to any value on
+                    an update.
+                  optionalOldSelf: true
+                  rule: oldSelf.hasValue() || self == 0
               patternObject:
                 description: This tests that pattern validator is properly applied.
                 pattern: ^$|^((https):\/\/?)[^\s()<>]+(?:\([\w\d]+\)|([^[:punct:]\s]|\/?))$


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

<!-- What does this do, and why do we need it? -->
